### PR TITLE
Fix for stream

### DIFF
--- a/src/models/stream.ts
+++ b/src/models/stream.ts
@@ -53,7 +53,11 @@ export class Stream extends Model {
 
     constructor() {
         super('stream', '2.1');
-        this.websocketUrl = `${baseUrl}/2.1/websocket/open`;
+        this.websocketUrl = `${baseUrl}`
+        if (!this.websocketUrl.endsWith("/")){
+            this.websocketUrl += `/`
+        }
+        this.websocketUrl += `2.1/websocket/open`;
 
         if (
             !this.websocketUrl.startsWith('http') &&

--- a/src/models/stream.ts
+++ b/src/models/stream.ts
@@ -54,7 +54,9 @@ export class Stream extends Model {
     constructor() {
         super('stream', '2.1');
         this.websocketUrl = `${baseUrl}`;
-        if (!this.websocketUrl.endsWith('/')){
+        if (
+            !this.websocketUrl.endsWith('/')
+        ) {
             this.websocketUrl += `/`;
         }
         this.websocketUrl += `2.1/websocket/open`;

--- a/src/models/stream.ts
+++ b/src/models/stream.ts
@@ -53,9 +53,9 @@ export class Stream extends Model {
 
     constructor() {
         super('stream', '2.1');
-        this.websocketUrl = `${baseUrl}`
-        if (!this.websocketUrl.endsWith("/")){
-            this.websocketUrl += `/`
+        this.websocketUrl = `${baseUrl}`;
+        if (!this.websocketUrl.endsWith('/')){
+            this.websocketUrl += `/`;
         }
         this.websocketUrl += `2.1/websocket/open`;
 

--- a/src/models/stream.ts
+++ b/src/models/stream.ts
@@ -54,9 +54,7 @@ export class Stream extends Model {
     constructor() {
         super('stream', '2.1');
         this.websocketUrl = `${baseUrl}`;
-        if (
-            !this.websocketUrl.endsWith('/')
-        ) {
+        if (!this.websocketUrl.endsWith('/')) {
             this.websocketUrl += `/`;
         }
         this.websocketUrl += `2.1/websocket/open`;


### PR DESCRIPTION
baseUrl in background is sent with an ending slash lie this: https://dev.wappsto.com/services/
Then when creating a stream you use this method:
baseUrl + "/2.1/websocket/open" 
and the result is something with two slash, like this:  https://dev.wappsto.com/services//2.1/websocket/open 

This PR is to fix this issue